### PR TITLE
Add service pages and Learn More links

### DIFF
--- a/ai-audit.html
+++ b/ai-audit.html
@@ -1,0 +1,126 @@
+<!-- ai-audit.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MEGA TECHNO TRON 3000 - AI Audit</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <header class="mtt3-header">
+  <div class="mtt3-header__container">
+    <span class="mtt3-header__logo">
+      <img src="assets/mtt-logo.svg" alt="mttM3000 logo" style="height: 34px; vertical-align: middle; display: inline-block; margin-right: 10px; margin-bottom:2px;">
+    </span>
+    <input type="checkbox" id="mtt3-menu-toggle" class="mtt3-header__toggle" />
+    <label for="mtt3-menu-toggle" class="mtt3-header__burger" tabindex="0" aria-label="Open navigation">
+      <span></span><span></span><span></span>
+    </label>
+    <nav class="mtt3-header__nav">
+      <a href="/#about">About Us</a>
+      <a href="/#process">How it Works</a>
+      <a href="/#cases">Cases</a>
+    </nav>
+    <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
+  </div>
+  </header>
+
+  <div class="window">
+    <div class="title-bar">[ AI_AUDIT.exe ]</div>
+    <h1>AI Audit</h1>
+    <p>You're considering AI but not sure where to start? We help you identify areas with clear automation potential.</p>
+    <a class="button" href="/">Back to MTT3000</a>
+  </div>
+
+<div class="win95-bar">
+  <div class="scroll-container">
+    <div class="scroll-content">
+      <span>ChatGPT</span>
+      <span>Gemini</span>
+      <span>Whisper</span>
+      <span>n8n</span>
+      <span>Zapier</span>
+      <span>Airtable</span>
+      <span>Trello</span>
+      <span>Google Sheets</span>
+      <span>Excel</span>
+      <span>HubSpot</span>
+      <span>Gmail</span>
+      <span>CRM</span>
+      <span>Copilot</span>
+      <span>Cursor</span>
+      <span>Jasper</span>
+      <span>Chatfuel</span>
+      <span>Google Analytics</span>
+      <span>Meta Ads Library</span>
+      <span>Facebook Ads</span>
+      <span>Claude</span>
+      <span>Perplexity</span>
+      <span>Midjourney</span>
+      <span>ElevenLabs</span>
+    </div>
+  </div>
+</div>
+
+  <footer>
+  <p>© 2025 - MEGA TECHNO TRON 3000 | Built with irony and <code>a sense of the point of no return.</code></p>
+    <p>Brutal business automations with AI via <a href="https://aspiratio.tech/" style="color: #00bfff; cursor: pointer;" target="_blank">Aspiratio Labs</a> | <a href="/privacy" style="color: #00bfff; cursor: pointer;" target="_blank">Privacy Policy</a></p>
+  <img src="/duck.png" alt="retro duck" style="width: 100px; margin-top: 1rem;"/>
+  <p style="font-family: monospace; font-size: 14px; color: #cc00ff;">
+  > CONTACT: <a href="mailto:root@mtt3000.com" style="color: #00bfff; cursor: pointer;">root@mtt3000.com</a> [re: AI_AUDIT]
+  </p>
+</footer>
+
+<!-- cookie banner-->
+<style>
+  #cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #000080;
+    color: #fff;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 6px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 9999;
+    box-shadow: 0 -1px 4px rgba(0,0,0,0.3);
+  }
+
+  #cookie-banner button {
+    background: #f4f4f4;
+    color: #000;
+    border: none;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+</style>
+
+<div id="cookie-banner">
+  <span>This site uses Smartlook for minimal analytics. When continue using the site you agree to our <a href="/privacy" style="color: #fff; text-decoration: underline;">Privacy Policy</a></span>
+  <button onclick="acceptCookies()">OK</button>
+</div>
+
+<script>
+  function acceptCookies() {
+    sessionStorage.setItem('cookiesAccepted', 'true');
+    document.getElementById('cookie-banner').style.display = 'none';
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    if (sessionStorage.getItem('cookiesAccepted')) {
+      document.getElementById('cookie-banner').style.display = 'none';
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/brutal-automation.html
+++ b/brutal-automation.html
@@ -1,0 +1,126 @@
+<!-- brutal-automation.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MEGA TECHNO TRON 3000 - Brutal Automation</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <header class="mtt3-header">
+  <div class="mtt3-header__container">
+    <span class="mtt3-header__logo">
+      <img src="assets/mtt-logo.svg" alt="mttM3000 logo" style="height: 34px; vertical-align: middle; display: inline-block; margin-right: 10px; margin-bottom:2px;">
+    </span>
+    <input type="checkbox" id="mtt3-menu-toggle" class="mtt3-header__toggle" />
+    <label for="mtt3-menu-toggle" class="mtt3-header__burger" tabindex="0" aria-label="Open navigation">
+      <span></span><span></span><span></span>
+    </label>
+    <nav class="mtt3-header__nav">
+      <a href="/#about">About Us</a>
+      <a href="/#process">How it Works</a>
+      <a href="/#cases">Cases</a>
+    </nav>
+    <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
+  </div>
+  </header>
+
+  <div class="window">
+    <div class="title-bar">[ BRUTAL_AUTOMATION.exe ]</div>
+    <h1>Brutal Automation</h1>
+    <p>We help you run smoothly by automating your business processes with GPT, n8n, Cursor and other tools. Minimum effort, maximum optimization.</p>
+    <a class="button" href="/">Back to MTT3000</a>
+  </div>
+
+<div class="win95-bar">
+  <div class="scroll-container">
+    <div class="scroll-content">
+      <span>ChatGPT</span>
+      <span>Gemini</span>
+      <span>Whisper</span>
+      <span>n8n</span>
+      <span>Zapier</span>
+      <span>Airtable</span>
+      <span>Trello</span>
+      <span>Google Sheets</span>
+      <span>Excel</span>
+      <span>HubSpot</span>
+      <span>Gmail</span>
+      <span>CRM</span>
+      <span>Copilot</span>
+      <span>Cursor</span>
+      <span>Jasper</span>
+      <span>Chatfuel</span>
+      <span>Google Analytics</span>
+      <span>Meta Ads Library</span>
+      <span>Facebook Ads</span>
+      <span>Claude</span>
+      <span>Perplexity</span>
+      <span>Midjourney</span>
+      <span>ElevenLabs</span>
+    </div>
+  </div>
+</div>
+
+  <footer>
+  <p>© 2025 - MEGA TECHNO TRON 3000 | Built with irony and <code>a sense of the point of no return.</code></p>
+    <p>Brutal business automations with AI via <a href="https://aspiratio.tech/" style="color: #00bfff; cursor: pointer;" target="_blank">Aspiratio Labs</a> | <a href="/privacy" style="color: #00bfff; cursor: pointer;" target="_blank">Privacy Policy</a></p>
+  <img src="/duck.png" alt="retro duck" style="width: 100px; margin-top: 1rem;"/>
+  <p style="font-family: monospace; font-size: 14px; color: #cc00ff;">
+  > CONTACT: <a href="mailto:root@mtt3000.com" style="color: #00bfff; cursor: pointer;">root@mtt3000.com</a> [re: AI_AUDIT]
+  </p>
+</footer>
+
+<!-- cookie banner-->
+<style>
+  #cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #000080;
+    color: #fff;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 6px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 9999;
+    box-shadow: 0 -1px 4px rgba(0,0,0,0.3);
+  }
+
+  #cookie-banner button {
+    background: #f4f4f4;
+    color: #000;
+    border: none;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+</style>
+
+<div id="cookie-banner">
+  <span>This site uses Smartlook for minimal analytics. When continue using the site you agree to our <a href="/privacy" style="color: #fff; text-decoration: underline;">Privacy Policy</a></span>
+  <button onclick="acceptCookies()">OK</button>
+</div>
+
+<script>
+  function acceptCookies() {
+    sessionStorage.setItem('cookiesAccepted', 'true');
+    document.getElementById('cookie-banner').style.display = 'none';
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    if (sessionStorage.getItem('cookiesAccepted')) {
+      document.getElementById('cookie-banner').style.display = 'none';
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/embedding-ai.html
+++ b/embedding-ai.html
@@ -1,0 +1,126 @@
+<!-- embedding-ai.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MEGA TECHNO TRON 3000 - Embedding AI</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <header class="mtt3-header">
+  <div class="mtt3-header__container">
+    <span class="mtt3-header__logo">
+      <img src="assets/mtt-logo.svg" alt="mttM3000 logo" style="height: 34px; vertical-align: middle; display: inline-block; margin-right: 10px; margin-bottom:2px;">
+    </span>
+    <input type="checkbox" id="mtt3-menu-toggle" class="mtt3-header__toggle" />
+    <label for="mtt3-menu-toggle" class="mtt3-header__burger" tabindex="0" aria-label="Open navigation">
+      <span></span><span></span><span></span>
+    </label>
+    <nav class="mtt3-header__nav">
+      <a href="/#about">About Us</a>
+      <a href="/#process">How it Works</a>
+      <a href="/#cases">Cases</a>
+    </nav>
+    <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
+  </div>
+  </header>
+
+  <div class="window">
+    <div class="title-bar">[ EMBEDDING_AI.exe ]</div>
+    <h1>Embedding AI</h1>
+    <p>We embed intelligence into your business workflows. We build tailored GPTs, AI models and predictive analytics tools.</p>
+    <a class="button" href="/">Back to MTT3000</a>
+  </div>
+
+<div class="win95-bar">
+  <div class="scroll-container">
+    <div class="scroll-content">
+      <span>ChatGPT</span>
+      <span>Gemini</span>
+      <span>Whisper</span>
+      <span>n8n</span>
+      <span>Zapier</span>
+      <span>Airtable</span>
+      <span>Trello</span>
+      <span>Google Sheets</span>
+      <span>Excel</span>
+      <span>HubSpot</span>
+      <span>Gmail</span>
+      <span>CRM</span>
+      <span>Copilot</span>
+      <span>Cursor</span>
+      <span>Jasper</span>
+      <span>Chatfuel</span>
+      <span>Google Analytics</span>
+      <span>Meta Ads Library</span>
+      <span>Facebook Ads</span>
+      <span>Claude</span>
+      <span>Perplexity</span>
+      <span>Midjourney</span>
+      <span>ElevenLabs</span>
+    </div>
+  </div>
+</div>
+
+  <footer>
+  <p>© 2025 - MEGA TECHNO TRON 3000 | Built with irony and <code>a sense of the point of no return.</code></p>
+    <p>Brutal business automations with AI via <a href="https://aspiratio.tech/" style="color: #00bfff; cursor: pointer;" target="_blank">Aspiratio Labs</a> | <a href="/privacy" style="color: #00bfff; cursor: pointer;" target="_blank">Privacy Policy</a></p>
+  <img src="/duck.png" alt="retro duck" style="width: 100px; margin-top: 1rem;"/>
+  <p style="font-family: monospace; font-size: 14px; color: #cc00ff;">
+  > CONTACT: <a href="mailto:root@mtt3000.com" style="color: #00bfff; cursor: pointer;">root@mtt3000.com</a> [re: AI_AUDIT]
+  </p>
+</footer>
+
+<!-- cookie banner-->
+<style>
+  #cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #000080;
+    color: #fff;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 6px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 9999;
+    box-shadow: 0 -1px 4px rgba(0,0,0,0.3);
+  }
+
+  #cookie-banner button {
+    background: #f4f4f4;
+    color: #000;
+    border: none;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+</style>
+
+<div id="cookie-banner">
+  <span>This site uses Smartlook for minimal analytics. When continue using the site you agree to our <a href="/privacy" style="color: #fff; text-decoration: underline;">Privacy Policy</a></span>
+  <button onclick="acceptCookies()">OK</button>
+</div>
+
+<script>
+  function acceptCookies() {
+    sessionStorage.setItem('cookiesAccepted', 'true');
+    document.getElementById('cookie-banner').style.display = 'none';
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    if (sessionStorage.getItem('cookiesAccepted')) {
+      document.getElementById('cookie-banner').style.display = 'none';
+    }
+  });
+</script>
+
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -115,18 +115,22 @@ Launching system core<span class="loading-line"></span>
       <div>
         <h2>💉 Embedding AI</h2>
         <p>We embed intelligence into your business workflows. We build tailored GPTs, AI-models, Predictive Analytics tools tailored to your needs.</p>
+        <a href="/embedding-ai">Learn More</a>
       </div>
       <div>
         <h2>🧠 Brutal Automation</h2>
         <p>We help you run smoothly by automating your business processes with GPT, n8n, Cursor and other tools. Minimum effort, maximum optimization.</p>
+        <a href="/brutal-automation">Learn More</a>
       </div>
       <div>
         <h2>⚙️ System Assembly</h2>
         <p>We review your current business tools and develop integrations with auto-triggers. Better processes with minimal changes and faster learning curve.</p>
+        <a href="/system-assembly">Learn More</a>
       </div>
       <div>
         <h2>🧰 AI Audit</h2>
         <p>You're considering AI but not sure where to start? We help you identify areas with clear automation potential.</p>
+        <a href="/ai-audit">Learn More</a>
       </div>
     </div>
   </div>

--- a/system-assembly.html
+++ b/system-assembly.html
@@ -1,0 +1,126 @@
+<!-- system-assembly.html -->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>MEGA TECHNO TRON 3000 - System Assembly</title>
+  <link rel="stylesheet" href="styles.css" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+  <script src="main.js" defer></script>
+</head>
+<body>
+  <header class="mtt3-header">
+  <div class="mtt3-header__container">
+    <span class="mtt3-header__logo">
+      <img src="assets/mtt-logo.svg" alt="mttM3000 logo" style="height: 34px; vertical-align: middle; display: inline-block; margin-right: 10px; margin-bottom:2px;">
+    </span>
+    <input type="checkbox" id="mtt3-menu-toggle" class="mtt3-header__toggle" />
+    <label for="mtt3-menu-toggle" class="mtt3-header__burger" tabindex="0" aria-label="Open navigation">
+      <span></span><span></span><span></span>
+    </label>
+    <nav class="mtt3-header__nav">
+      <a href="/#about">About Us</a>
+      <a href="/#process">How it Works</a>
+      <a href="/#cases">Cases</a>
+    </nav>
+    <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
+  </div>
+  </header>
+
+  <div class="window">
+    <div class="title-bar">[ SYSTEM_ASSEMBLY.exe ]</div>
+    <h1>System Assembly</h1>
+    <p>We review your current business tools and develop integrations with auto-triggers. Better processes with minimal changes and faster learning curve.</p>
+    <a class="button" href="/">Back to MTT3000</a>
+  </div>
+
+<div class="win95-bar">
+  <div class="scroll-container">
+    <div class="scroll-content">
+      <span>ChatGPT</span>
+      <span>Gemini</span>
+      <span>Whisper</span>
+      <span>n8n</span>
+      <span>Zapier</span>
+      <span>Airtable</span>
+      <span>Trello</span>
+      <span>Google Sheets</span>
+      <span>Excel</span>
+      <span>HubSpot</span>
+      <span>Gmail</span>
+      <span>CRM</span>
+      <span>Copilot</span>
+      <span>Cursor</span>
+      <span>Jasper</span>
+      <span>Chatfuel</span>
+      <span>Google Analytics</span>
+      <span>Meta Ads Library</span>
+      <span>Facebook Ads</span>
+      <span>Claude</span>
+      <span>Perplexity</span>
+      <span>Midjourney</span>
+      <span>ElevenLabs</span>
+    </div>
+  </div>
+</div>
+
+  <footer>
+  <p>© 2025 - MEGA TECHNO TRON 3000 | Built with irony and <code>a sense of the point of no return.</code></p>
+    <p>Brutal business automations with AI via <a href="https://aspiratio.tech/" style="color: #00bfff; cursor: pointer;" target="_blank">Aspiratio Labs</a> | <a href="/privacy" style="color: #00bfff; cursor: pointer;" target="_blank">Privacy Policy</a></p>
+  <img src="/duck.png" alt="retro duck" style="width: 100px; margin-top: 1rem;"/>
+  <p style="font-family: monospace; font-size: 14px; color: #cc00ff;">
+  > CONTACT: <a href="mailto:root@mtt3000.com" style="color: #00bfff; cursor: pointer;">root@mtt3000.com</a> [re: AI_AUDIT]
+  </p>
+</footer>
+
+<!-- cookie banner-->
+<style>
+  #cookie-banner {
+    position: fixed;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    background: #000080;
+    color: #fff;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 6px 12px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    z-index: 9999;
+    box-shadow: 0 -1px 4px rgba(0,0,0,0.3);
+  }
+
+  #cookie-banner button {
+    background: #f4f4f4;
+    color: #000;
+    border: none;
+    font-family: monospace;
+    font-size: 12px;
+    padding: 3px 8px;
+    cursor: pointer;
+  }
+</style>
+
+<div id="cookie-banner">
+  <span>This site uses Smartlook for minimal analytics. When continue using the site you agree to our <a href="/privacy" style="color: #fff; text-decoration: underline;">Privacy Policy</a></span>
+  <button onclick="acceptCookies()">OK</button>
+</div>
+
+<script>
+  function acceptCookies() {
+    sessionStorage.setItem('cookiesAccepted', 'true');
+    document.getElementById('cookie-banner').style.display = 'none';
+  }
+
+  window.addEventListener('DOMContentLoaded', () => {
+    if (sessionStorage.getItem('cookiesAccepted')) {
+      document.getElementById('cookie-banner').style.display = 'none';
+    }
+  });
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary
- create dedicated pages for each service (Embedding AI, Brutal Automation, System Assembly, AI Audit)
- link each "What We Do" item on the homepage to its corresponding page

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840a547127c832a952dede786b5acfb