### PR TITLE
Add service pages with working modals

### DIFF
--- a/ai-audit.html
+++ b/ai-audit.html
@@ -68,17 +68,18 @@ Launching system core<span class="loading-line"></span>
       <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
     </div>
 
-    <!-- calcom modal -->
-    <div id="pdf-modal" class="win95-modal">
-      <div class="win95-modal-content">
-        <div class="win95-titlebar">
-          <span>[ AUDIT_SCHEDULER.exe ]</span>
-          <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
-        </div>
-        <iframe id="pdf-frame" src=""></iframe>
-      </div>
+   <!-- calcom modal -->
+<div id="pdf-modal" class="win95-modal">
+  <div class="win95-modal-content">
+    <div class="win95-titlebar">
+      <span>[ AUDIT_SCHEDULER.exe ]</span>
+      <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
-  </header>
+    <iframe id="pdf-frame" src=""></iframe>
+  </div>
+</div>
+
+</header>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 

--- a/brutal-automation.html
+++ b/brutal-automation.html
@@ -68,17 +68,18 @@ Launching system core<span class="loading-line"></span>
       <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
     </div>
 
-    <!-- calcom modal -->
-    <div id="pdf-modal" class="win95-modal">
-      <div class="win95-modal-content">
-        <div class="win95-titlebar">
-          <span>[ AUDIT_SCHEDULER.exe ]</span>
-          <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
-        </div>
-        <iframe id="pdf-frame" src=""></iframe>
-      </div>
+   <!-- calcom modal -->
+<div id="pdf-modal" class="win95-modal">
+  <div class="win95-modal-content">
+    <div class="win95-titlebar">
+      <span>[ AUDIT_SCHEDULER.exe ]</span>
+      <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
-  </header>
+    <iframe id="pdf-frame" src=""></iframe>
+  </div>
+</div>
+
+</header>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 

--- a/embedding-ai.html
+++ b/embedding-ai.html
@@ -68,17 +68,18 @@ Launching system core<span class="loading-line"></span>
       <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
     </div>
 
-    <!-- calcom modal -->
-    <div id="pdf-modal" class="win95-modal">
-      <div class="win95-modal-content">
-        <div class="win95-titlebar">
-          <span>[ AUDIT_SCHEDULER.exe ]</span>
-          <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
-        </div>
-        <iframe id="pdf-frame" src=""></iframe>
-      </div>
+   <!-- calcom modal -->
+<div id="pdf-modal" class="win95-modal">
+  <div class="win95-modal-content">
+    <div class="win95-titlebar">
+      <span>[ AUDIT_SCHEDULER.exe ]</span>
+      <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
-  </header>
+    <iframe id="pdf-frame" src=""></iframe>
+  </div>
+</div>
+
+</header>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 

--- a/system-assembly.html
+++ b/system-assembly.html
@@ -68,17 +68,18 @@ Launching system core<span class="loading-line"></span>
       <a href="https://cal.com/mtt3000/ai-patch-preview-call" class="mtt3-header__cta open-in-modal">BOOK AUDIT</a>
     </div>
 
-    <!-- calcom modal -->
-    <div id="pdf-modal" class="win95-modal">
-      <div class="win95-modal-content">
-        <div class="win95-titlebar">
-          <span>[ AUDIT_SCHEDULER.exe ]</span>
-          <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
-        </div>
-        <iframe id="pdf-frame" src=""></iframe>
-      </div>
+   <!-- calcom modal -->
+<div id="pdf-modal" class="win95-modal">
+  <div class="win95-modal-content">
+    <div class="win95-titlebar">
+      <span>[ AUDIT_SCHEDULER.exe ]</span>
+      <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
-  </header>
+    <iframe id="pdf-frame" src=""></iframe>
+  </div>
+</div>
+
+</header>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 


### PR DESCRIPTION
## Summary
- create basic service pages for Embedding AI, Brutal Automation, System Assembly and AI Audit
- copy the pdf modal block so `main.js` works on every page

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6840aa861600832aba65d5bce3c38011