### PR TITLE
Add service buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -115,18 +115,22 @@ Launching system core<span class="loading-line"></span>
       <div>
         <h2>💉 Embedding AI</h2>
         <p>We embed intelligence into your business workflows. We build tailored GPTs, AI-models, Predictive Analytics tools tailored to your needs.</p>
+        <a href="embedding-ai.html" class="button">View service</a>
       </div>
       <div>
         <h2>🧠 Brutal Automation</h2>
         <p>We help you run smoothly by automating your business processes with GPT, n8n, Cursor and other tools. Minimum effort, maximum optimization.</p>
+        <a href="brutal-automation.html" class="button">View service</a>
       </div>
       <div>
         <h2>⚙️ System Assembly</h2>
         <p>We review your current business tools and develop integrations with auto-triggers. Better processes with minimal changes and faster learning curve.</p>
+        <a href="system-assembly.html" class="button">View service</a>
       </div>
       <div>
         <h2>🧰 AI Audit</h2>
         <p>You're considering AI but not sure where to start? We help you identify areas with clear automation potential.</p>
+        <a href="ai-audit.html" class="button">View service</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Summary
- add dedicated buttons to service pages in the "What We Do" block

## Testing
- `npm test` *(fails: could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6840aec3d0f8832ab8cb697f98fbebbe