### PR TITLE
Add breadcrumbs and back button to service pages

### DIFF
--- a/ai-audit.html
+++ b/ai-audit.html
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; AI Audit
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 

--- a/brutal-automation.html
+++ b/brutal-automation.html
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; Brutal Automation
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 

--- a/embedding-ai.html
+++ b/embedding-ai.html
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; Embedding AI
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 

--- a/styles.css
+++ b/styles.css
@@ -584,3 +584,25 @@ form label {
   margin: 0 auto;
   display: block;
 }
+
+/* breadcrumbs and back button */
+.breadcrumbs {
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+  margin: 0.5rem 0 1rem 1rem;
+}
+.back-link {
+  background: var(--win95-light-grey);
+  border: 2px outset var(--win95-border);
+  padding: 0.3rem 0.8rem;
+  font-weight: bold;
+  text-decoration: none;
+  color: #000;
+  box-shadow: 2px 2px 0 var(--win95-dark-grey);
+  margin-right: 0.5rem;
+}
+.back-link:hover {
+  background: var(--win95-blue);
+  color: #fff;
+  box-shadow: 2px 2px 4px #000;
+}

--- a/system-assembly.html
+++ b/system-assembly.html
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; System Assembly
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 


### PR DESCRIPTION
## Summary
- added breadcrumbs and a Back link to each service page
- styled new breadcrumb elements in CSS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6840b6cfe540832ab45c9c32dd600f49