### PR TITLE
Refine service pages navigation

### DIFF
--- a/ai-audit.html
+++ b/ai-audit.html
@@ -61,7 +61,7 @@ Launching system core<span class="loading-line"></span>
         <span></span><span></span><span></span>
       </label>
       <nav class="mtt3-header__nav">
-        <a href="/">Home</a>
+        <a href="/#about">About</a>
         <a href="/#process">How it Works</a>
         <a href="/#cases">Cases</a>
       </nav>
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; AI Audit
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 
@@ -87,7 +92,6 @@ Launching system core<span class="loading-line"></span>
     <div class="title-bar">[ AI_AUDIT.exe ]</div>
     <h1>AI Audit</h1>
     <p>We help identify areas with clear automation potential and show you where to start.</p>
-    <a class="button open-in-modal" href="https://cal.com/mtt3000/ai-patch-preview-call">Book audit call</a>
   </div>
 
 <div class="win95-bar">

--- a/brutal-automation.html
+++ b/brutal-automation.html
@@ -61,7 +61,7 @@ Launching system core<span class="loading-line"></span>
         <span></span><span></span><span></span>
       </label>
       <nav class="mtt3-header__nav">
-        <a href="/">Home</a>
+        <a href="/#about">About</a>
         <a href="/#process">How it Works</a>
         <a href="/#cases">Cases</a>
       </nav>
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; Brutal Automation
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 
@@ -87,7 +92,6 @@ Launching system core<span class="loading-line"></span>
     <div class="title-bar">[ BRUTAL_AUTOMATION.exe ]</div>
     <h1>Brutal Automation</h1>
     <p>We automate your business processes with GPT, n8n and other tools. Minimum effort, maximum optimization.</p>
-    <a class="button open-in-modal" href="https://cal.com/mtt3000/ai-patch-preview-call">Book audit call</a>
   </div>
 
 <div class="win95-bar">

--- a/embedding-ai.html
+++ b/embedding-ai.html
@@ -61,7 +61,7 @@ Launching system core<span class="loading-line"></span>
         <span></span><span></span><span></span>
       </label>
       <nav class="mtt3-header__nav">
-        <a href="/">Home</a>
+        <a href="/#about">About</a>
         <a href="/#process">How it Works</a>
         <a href="/#cases">Cases</a>
       </nav>
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; Embedding AI
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 
@@ -87,7 +92,6 @@ Launching system core<span class="loading-line"></span>
     <div class="title-bar">[ EMBEDDING_AI.exe ]</div>
     <h1>Embedding AI</h1>
     <p>We embed intelligence into your business workflows. We build tailored GPTs, AI-models and predictive analytics tools.</p>
-    <a class="button open-in-modal" href="https://cal.com/mtt3000/ai-patch-preview-call">Book audit call</a>
   </div>
 
 <div class="win95-bar">

--- a/styles.css
+++ b/styles.css
@@ -584,3 +584,25 @@ form label {
   margin: 0 auto;
   display: block;
 }
+
+/* breadcrumbs and back button */
+.breadcrumbs {
+  font-family: 'Courier New', monospace;
+  font-size: 0.9rem;
+  margin: 0.5rem 0 1rem 1rem;
+}
+.back-link {
+  background: var(--win95-light-grey);
+  border: 2px outset var(--win95-border);
+  padding: 0.3rem 0.8rem;
+  font-weight: bold;
+  text-decoration: none;
+  color: #000;
+  box-shadow: 2px 2px 0 var(--win95-dark-grey);
+  margin-right: 0.5rem;
+}
+.back-link:hover {
+  background: var(--win95-blue);
+  color: #fff;
+  box-shadow: 2px 2px 4px #000;
+}

--- a/system-assembly.html
+++ b/system-assembly.html
@@ -61,7 +61,7 @@ Launching system core<span class="loading-line"></span>
         <span></span><span></span><span></span>
       </label>
       <nav class="mtt3-header__nav">
-        <a href="/">Home</a>
+        <a href="/#about">About</a>
         <a href="/#process">How it Works</a>
         <a href="/#cases">Cases</a>
       </nav>
@@ -76,10 +76,15 @@ Launching system core<span class="loading-line"></span>
       <button id="close-pdf-btn" class="win95-close-btn">&times;</button>
     </div>
     <iframe id="pdf-frame" src=""></iframe>
-  </div>
+</div>
 </div>
 
 </header>
+
+  <nav class="breadcrumbs">
+    <a href="/" class="back-link">&larr; Back</a>
+    Home &gt; System Assembly
+  </nav>
 
   <canvas id="duck-canvas" style="position: fixed; top: 0; left: 0; z-index: 999;"></canvas>
 
@@ -87,7 +92,6 @@ Launching system core<span class="loading-line"></span>
     <div class="title-bar">[ SYSTEM_ASSEMBLY.exe ]</div>
     <h1>System Assembly</h1>
     <p>We review your current tools and build integrations with auto-triggers for smoother processes.</p>
-    <a class="button open-in-modal" href="https://cal.com/mtt3000/ai-patch-preview-call">Book audit call</a>
   </div>
 
 <div class="win95-bar">


### PR DESCRIPTION
## Summary
- swapped Home link for About in service page headers
- removed in-page 'Book audit call' buttons

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6840b6cfe540832ab45c9c32dd600f49